### PR TITLE
Add staging on Archive functions. Remove IPv6 addresses from host pool

### DIFF
--- a/scripts/univMSSInterface_generic.sh
+++ b/scripts/univMSSInterface_generic.sh
@@ -21,8 +21,9 @@
 
 # Changelog:
 # 2016-07-01 - v1.00 - RV - create initial univMSSInterface_generic.sh from univMSSInterface.sh
+# 2017-05-10 - v1.01 - RV - add staging on Archive functions
 
-VERSION=v1.00
+VERSION=v1.01
 PROG=`basename $0`
 FILEPATH=`dirname $0`
 
@@ -45,6 +46,8 @@ case "$1" in
 	rm )    $univMSSInterface $1 $2 ;;
 	mv )    $univMSSInterface $1 $2 $3 ;;
 	stat )  $univMSSInterface $1 $2 ;;
+	stageOnArch )  $univMSSInterface $1 $2 ;;
+	checkOnArch )  $univMSSInterface $1 $2 ;;
 esac
 
 exit $?


### PR DESCRIPTION
Add staging on Archive functions. Remove IPv6 addresses from host pool.

We add some extra functions:
* stageOnArch
* checkOnArch

`stageOnArch` stages the file from tape or whatever to archive so it is local on the archive. This is done in the background.
`checkOnArch` checks the status of a file on the archive to see if it is local on the archive. 

This way you are able to do:
- stage files on the archive in the background.
- check the presence of a file on the archive.

This has to do with the fact that some systems use a HSM as storage backend. This way you are able to stage files on the archive before getting them with iRODS.